### PR TITLE
Use child_process.spawnSync instead of execSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "license": "WTFPL",
   "dependencies": {
     "coa": "^0.4.1",
-    "execSync": "^1.0.2",
     "extend": "^1.3.0",
     "contimer": "^1.0.1",
     "moment": "^2.8.3",

--- a/packrat.js
+++ b/packrat.js
@@ -2,7 +2,7 @@ var path = require('path'),
     fs = require('fs'),
     crypto = require('crypto'),
     util = require('util'),
-    sh = require('execSync'),
+    spawnSync = require('child_process').spawnSync,
     messages = require('./lib/messages'),
     timer = require('contimer'),
     moment = require('moment'),
@@ -177,7 +177,7 @@ Packrat.prototype.realInstall = function() {
     timer.start(this, 'realInstall');
 
     this.log(messages.USUAL_INSTALL());
-    this.installLog = this.runCommand(this.installCommand).stdout;
+    this.installLog = String(this.runCommand(this.installCommand).stdout);
     this.installTime = timer.stop(this, 'realInstall').time;
 };
 
@@ -230,14 +230,14 @@ Packrat.prototype.runCommand = function() {
         this.log('Packrat is running `%s`...', command);
     }
 
-    result = sh.exec(command, true);
+    result = spawnSync('sh', [ '-c', command ]);
 
     if (result.stdout) {
-        this.log(result.stdout);
+        this.log(String(result.stdout));
     }
 
-    if (result.code !== 0) {
-        this.onError(new Error(util.format('`%s` command failed', command)), result.code);
+    if (result.status !== 0) {
+        this.onError(new Error(util.format('`%s` command failed', command)), result.status);
     }
 
     return result;


### PR DESCRIPTION
WARNING: It breaks backward compatibility.

Pros:
- no need to configure [node-gyp](https://github.com/mgutz/execSync/issues/27) anymore;
- get child process stderr and stdout piped to console.

Cons:
- it doesn’t work under node v0.10. [child_process.spawnSync](https://nodejs.org/docs/v0.12.0/api/child_process.html#child_process_child_process_spawnsync_command_args_options) appear in node v0.12.
